### PR TITLE
Refactor Docker 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
     WORKDIR /app
     
     # Copy built code and node_modules from builder
-    COPY --from=builder /app/dist ./src
+    COPY --from=builder /app/dist/src ./src
     COPY --from=builder /app/node_modules ./node_modules
     COPY --from=builder /app/package.json ./
     COPY --from=builder /app/.env ./


### PR DESCRIPTION
This pull request includes a fix to the `Dockerfile` to correct the path for copying the built code from the builder stage. 

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-R21): Updated the `COPY` command to use the correct path (`/app/dist/src` instead of `/app/dist`) for copying the built code into the final image.