### PR TITLE
Refactor Dockerfile to copy build output to separate directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-    FROM node:23-alpine AS builder
+    FROM node:23-alpine
 
     WORKDIR /app
     
@@ -18,7 +18,7 @@
     WORKDIR /app
     
     # Copy built code and node_modules from builder
-    COPY --from=builder /app/dist/src ./src
+    COPY --from=builder /app/dist ./dist
     COPY --from=builder /app/node_modules ./node_modules
     COPY --from=builder /app/package.json ./
     COPY --from=builder /app/.env ./


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` to streamline the build process and fix a path inconsistency. The most important changes are the removal of the multi-stage build setup and correcting the path for the copied build artifacts.

**Dockerfile updates:**

* Removed the `AS builder` alias from the `FROM node:23-alpine` statement, eliminating the multi-stage build setup.
* Updated the `COPY` command to adjust the path for build artifacts, copying the entire `dist` directory instead of the `dist/src` subdirectory.